### PR TITLE
change the ordering of hostnames in hosts

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
   become: yes
   lineinfile:
     dest: /etc/hosts
-    line: "127.0.0.1 localhost {{ ansible_hostname }}"
+    line: "127.0.0.1 {{ ansible_hostname }} {{ inventory_hostname }} localhost"
     regexp: ^127\.0\.0\.1
 
 - name: Ensure ssmtp configuration


### PR DESCRIPTION
I noticed that on Debian wheezy the ordering provided by your role seems to make rsyslog use hostname localhost rather then the ansible_hostname for syslog messages.

I made quickfix with this patch to resolve it for myself, as of debian wheezy will be eoled in May next year there isnt that much of time left for its usage so maybe its not worth it to have wheezy specific fix for it.

I can make the change wheezy specific if you want, but up to you if you want to incldue it or not.
Aswell there is question should the inventory_hostname inclusion be configurable or not.

not sure if chaning the ordering breaks anything else.
Debian Jessie and Stretch arent affected.



