### PR TITLE
[GITHUB-9] Fixes conf directory perms

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -14,14 +14,15 @@ def test_packages(host):
 
 
 def test_files(host):
-    revaliases = host.file('/etc/ssmtp/revaliases').content_string
-    assert 'ssmtp_user:john_doe:localhost:25' in revaliases
-
-    ssmtp_conf = host.file('/etc/ssmtp/ssmtp.conf').content_string
-    assert 'AuthUser=john_doe' in ssmtp_conf
-    assert 'AuthPass=swordfish' in ssmtp_conf
-
     ssmtp_exe = host.file('/usr/sbin/ssmtp')
     assert ssmtp_exe.user == 'ssmtp_user'
     assert ssmtp_exe.group == 'ssmtp_group'
     assert ssmtp_exe.mode == 0o770
+
+    with host.sudo('ssmtp_user'):
+        revaliases = host.file('/etc/ssmtp/revaliases').content_string
+        assert 'ssmtp_user:john_doe:localhost:25' in revaliases
+
+        ssmtp_conf = host.file('/etc/ssmtp/ssmtp.conf').content_string
+        assert 'AuthUser=john_doe' in ssmtp_conf
+        assert 'AuthPass=swordfish' in ssmtp_conf

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,7 +30,7 @@
   file:
     dest: /etc/ssmtp
     group: "{{ sansible_ssmtp_group }}"
-    mode: 0600
+    mode: 0700
     owner: "{{ sansible_ssmtp_user }}"
     state: directory
   when:


### PR DESCRIPTION
Ensures that the executable bit is in place for the config dir,
directory is not accessible without it.