### PR TITLE
add additional configuration options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,6 @@ sansible_ssmtp_restrict: yes
 sansible_ssmtp_revaliases: yes
 sansible_ssmtp_use_inventory_hostname: no
 sansible_ssmtp_user: ~
+sansible_ssmtp_hostname: ''
+sansible_ssmtp_use_tls: true
+sansible_ssmtp_use_start_tls: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 sansible_ssmtp_auth: yes
 sansible_ssmtp_group: ~
+sansible_ssmtp_hostname: ''
 sansible_ssmtp_mailserver_fromlineoverride: no
 sansible_ssmtp_mailserver_host: ~
 sansible_ssmtp_mailserver_password: ~
@@ -12,7 +13,6 @@ sansible_ssmtp_mailserver_username: ~
 sansible_ssmtp_restrict: yes
 sansible_ssmtp_revaliases: yes
 sansible_ssmtp_use_inventory_hostname: no
-sansible_ssmtp_user: ~
-sansible_ssmtp_hostname: ''
-sansible_ssmtp_use_tls: true
 sansible_ssmtp_use_start_tls: true
+sansible_ssmtp_use_tls: true
+sansible_ssmtp_user: ~

--- a/templates/ssmtp.conf.j2
+++ b/templates/ssmtp.conf.j2
@@ -9,10 +9,17 @@ RewriteDomain={{ sansible_ssmtp_mailserver_rewritedomain }}
 {% if sansible_ssmtp_mailserver_fromlineoverride != false %}
 FromLineOverride={{ sansible_ssmtp_mailserver_fromlineoverride }}
 {% endif %}
+{% if sansible_ssmtp_use_tls %}
 UseTLS=Yes
+{% endif %}
+{% if sansible_ssmtp_use_start_tls %}
 UseSTARTTLS=Yes
+{% endif %}
 {% if sansible_ssmtp_use_inventory_hostname == true %}
 hostname={{ inventory_hostname }}
+{% endif %}
+{% if sansible_ssmtp_use_inventory_hostname == false and sansible_ssmtp_hostname != '' %}
+hostname={{ sansible_ssmtp_hostname }}
 {% endif %}
 {% if sansible_ssmtp_auth == true %}
 AuthUser={{ sansible_ssmtp_mailserver_username }}


### PR DESCRIPTION
Introducing additional configuration options:

* `sansible_ssmtp_hostname`
* `sansible_ssmtp_use_start_tls`
* `sansible_ssmtp_use_tls`

Defaults are intact, and changes in this PR should be backwards-compatible.