### PR TITLE
Fix 'ansible_virtualization_type' is undefined

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,7 +6,7 @@
     dest: /etc/hosts
     line: "127.0.0.1 localhost {{ ansible_hostname }}"
     regexp: ^127\.0\.0\.1
-  when: ansible_virtualization_type != 'docker'
+  when: ansible_virtualization_type is not defined or ansible_virtualization_type != 'docker'
 
 - name: Install SSMTP
   become: yes


### PR DESCRIPTION
In some cases is ansible_virtualization_type variable isn't set. Then the condition from install.yml fail. 