### PR TITLE
`sansible_ssmtp_group` user cannot send email.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,7 +13,7 @@
   template:
     dest: "/etc/ssmtp/{{ item }}"
     group: "{{ sansible_ssmtp_group }}"
-    mode: 0600
+    mode: 0640
     owner: "{{ sansible_ssmtp_user }}"
     src: "{{ item }}.j2"
   with_items:


### PR DESCRIPTION
Even with the user in the `sansible_ssmtp_group` group (set as `mail` on my system) I cannot send email apart from as root.
The config files in the /etc/ssmtp directory need read access for the group as well as the owner. Changing them to 640 allows users in the `sansible_ssmtp_group` group to send emails.