### PR TITLE
Support for centos and fixed connectivity to gmail

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,8 +10,9 @@
 
 - name: Install SSMTP
   become: yes
-  apt:
+  package:
     name: ssmtp
+    state: present
 
 - name: "Restrict SSMTP Usage to User {{ sansible_ssmtp_user }} and Group {{ sansible_ssmtp_group }}"
   become: yes

--- a/templates/ssmtp.conf.j2
+++ b/templates/ssmtp.conf.j2
@@ -14,6 +14,7 @@ UseTLS=Yes
 {% endif %}
 {% if sansible_ssmtp_use_start_tls %}
 UseSTARTTLS=Yes
+TLS_CA_File=/etc/pki/tls/certs/ca-bundle.crt
 {% endif %}
 {% if sansible_ssmtp_use_inventory_hostname == true %}
 hostname={{ inventory_hostname }}


### PR DESCRIPTION
1.  Changed **apt** to **package** to support RHEL distros
2.  gmail requiere TLS_CA_File in ssmtp.conf to successfully connect