### PR TITLE
Update hosts file consistently

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
   become: yes
   lineinfile:
     dest: /etc/hosts
-    line: "127.0.0.1 localhost {{ ansible_hostname }}"
+    line: "127.0.0.1 {{ ansible_hostname }} {{ inventory_hostname }} localhost"
     regexp: ^127\.0\.0\.1
   when: ansible_virtualization_type != 'docker'
 


### PR DESCRIPTION
Refs #16 
I'm still not entirely sure on the rationale for checking the hosts file in both install and configure steps but this PR makes them not conflict with each other.

Ensures both the configure and install steps make the same change to the hosts file so that they don't overwrite each other.